### PR TITLE
fix Invalid specifier: '>=3.7.*'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,7 @@ pip-selfcheck.json
 !.vscode/launch.json
 !.vscode/extensions.json
 *.code-workspace
+.DS_Store
 
 # Local History for Visual Studio Code
 .history/

--- a/brfinance/backend.py
+++ b/brfinance/backend.py
@@ -45,8 +45,7 @@ class CVMAsyncBackend():
             participant_type = ['-1']
 
         response = self._http_client().get_search_results(
-            cod_cvm=str(
-                ",".join([str(item) for item in cod_cvm])),
+            cod_cvm=cod_cvm,
             start_date=start_date,
             end_date=end_date,
             category=",".join(category),

--- a/brfinance/http_client.py
+++ b/brfinance/http_client.py
@@ -58,7 +58,6 @@ class CVMHttpClient():
             'Accept-Encoding': 'gzip, deflate, br',
             'Accept-Language': 'pt-BR,pt;q=0.9,en-US;q=0.8,en;q=0.7',
             'Connection': 'keep-alive',
-            'Content-Length': '324',
             'Content-Type': 'application/json; charset=UTF-8',
             'DNT': '1',
             'sec-ch-ua': '" Not A;Brand";v="99", "Chromium";v="96", "Google Chrome";v="96"',

--- a/brfinance/http_client.py
+++ b/brfinance/http_client.py
@@ -34,9 +34,17 @@ class CVMHttpClient():
         if (str(cod_cvm)) and (str(cod_cvm) is not None):
             cod_cvm = str(cod_cvm).zfill(6)
 
-        if start_date and end_date:
-            dataDe = start_date.strftime("%d/%m/%Y")
-            dataAte = end_date.strftime("%d/%m/%Y")
+        if start_date or end_date:
+            try:
+              dataDe = start_date.strftime("%d/%m/%Y")
+            except:
+              dataDe = ''
+
+            try:
+              dataAte = end_date.strftime("%d/%m/%Y")
+            except:
+              dataAte = ''
+
             periodo = "2"
         else:
             dataDe = ""
@@ -63,7 +71,8 @@ class CVMHttpClient():
             'x-dtpc': '28$428327064_275h18vMIPKIVDJMJWUHHIHJSUAWKKKMKVABKHO-0e0',
             'X-Requested-With': 'XMLHttpRequest'}
 
-        data = "{" + f"""dataDe: '{dataDe}',
+        data = "{" + f"""
+                dataDe: '{dataDe}',
                 dataAte: '{dataAte}' ,
                 empresa: '{cod_cvm}',
                 setorAtividade: '-1',
@@ -79,7 +88,8 @@ class CVMHttpClient():
                 ultimaDtRef:'{ultimaDtRef}',
                 tipoEmpresa:'0',
                 token: '',
-                versaoCaptcha: ''""" + "}"
+                versaoCaptcha: ''
+                """ + "}"
 
         resp = self.session.post(
             self.LISTAR_DOCUMENTOS_URL, data=data, headers=headers, verify=False)

--- a/brfinance/http_client.py
+++ b/brfinance/http_client.py
@@ -23,7 +23,7 @@ class CVMHttpClient():
 
     def get_search_results(
             self,
-            cod_cvm: str,
+            cod_cvm: list,
             start_date: date,
             end_date: date,
             participant_type: str,
@@ -31,8 +31,10 @@ class CVMHttpClient():
             last_ref_date
     ):
 
-        if (str(cod_cvm)) and (str(cod_cvm) is not None):
-            cod_cvm = str(cod_cvm).zfill(6)
+        cod_cvm_string = ''
+
+        if len(cod_cvm) > 0:
+            cod_cvm_string = str(",".join([f"{item}".zfill(6) for item in cod_cvm]))
 
         if start_date or end_date:
             try:
@@ -73,7 +75,7 @@ class CVMHttpClient():
         data = "{" + f"""
                 dataDe: '{dataDe}',
                 dataAte: '{dataAte}' ,
-                empresa: '{cod_cvm}',
+                empresa: '{cod_cvm_string}',
                 setorAtividade: '-1',
                 categoriaEmissor: '-1',
                 situacaoEmissor: '-1',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
     name='brfinance',
     version='0.0.9',
     packages=setuptools.find_packages(),
-    python_requires='>=3.7.*',
+    python_requires='>=3.7',
     author='Eudes Rodrigo Nunes de Oliveira',
     author_email='eudesrodrigo@outlook.com',
     description=(


### PR DESCRIPTION
Ontem comecei a ter o seguinte erro usando Python 3.9.16:

```
error in brfinance setup command: 'python_requires' must be a string containing valid version specifiers; Invalid specifier: '>=3.7.*'
```

Removendo o `*` funciona.